### PR TITLE
Fix connection issue by Adding *.connect.aws to CSP

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta http-equiv= "Content-Security-Policy" content="default-src blob: data: gap: wss: 'unsafe-inline' 'unsafe-eval' 'self' *.chime.aws *.cloudfront.net *.amazonaws.com;">
+<meta http-equiv="Content-Security-Policy" content="default-src blob: data: gap: wss: 'unsafe-inline' 'unsafe-eval' 'self' *.connect.aws *.chime.aws *.cloudfront.net *.amazonaws.com;">
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
**Problem**
The Amazon Connect Communication Widget was failing to connect and not functioning properly on our website. After investigation, we discovered that the Content Security Policy (CSP) was missing a critical domain required for the Connect Widget to establish connections correctly.

**Solution**
Added `*.connect.aws` to the Content Security Policy meta tag to allow communication with Amazon Connect services. 

```diff
- <meta http-equiv="Content-Security-Policy" content="default-src blob: data: gap: wss: 'unsafe-inline' 'unsafe-eval' 'self' *.chime.aws *.cloudfront.net *.amazonaws.com;">
+ <meta http-equiv="Content-Security-Policy" content="default-src blob: data: gap: wss: 'unsafe-inline' 'unsafe-eval' 'self' *.connect.aws *.chime.aws *.cloudfront.net *.amazonaws.com;">
```

**Testing**
This change was verified through testing. After adding the domain to the CSP:
- The Amazon Connect Communication Widget successfully established connections
- Voice/video calling functionality worked as expected
- Customer information was properly passed to the Agent Workspace

**Impact**
This is a minor change that only affects the Content Security Policy. It does not modify any functionality but enables the intended behavior of our Amazon Connect integration by resolving the connection issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
